### PR TITLE
Use `SDL_MAIN_USE_CALLBACKS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ add_subdirectory(SDL EXCLUDE_FROM_ALL)
 
 # Link SDL to our executable. This also makes its include directory available to us. 
 target_link_libraries(${EXECUTABLE_NAME} PUBLIC SDL3::SDL3)
+target_compile_definitions(${EXECUTABLE_NAME} PUBLIC SDL_MAIN_USE_CALLBACKS)
 
 # set some extra configs for each platform
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,62 +1,34 @@
 #include <iostream>
-#include <SDL.h>
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
 #include <cmath>
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
-//On UWP, we need to not have SDL_main otherwise we'll get a linker error
-#define SDL_MAIN_HANDLED
-#endif
-#include <SDL_main.h>
-#if __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
 
-void SDL_Fail(){
+typedef struct app_data {
+    SDL_Window* window;
+    SDL_Renderer* renderer;
+    SDL_bool app_quit;
+} app_data;
+
+int SDL_Fail(){
     SDL_LogError(SDL_LOG_CATEGORY_CUSTOM, "Error %s", SDL_GetError());
-    exit(1);
+    return -1;
 }
 
-static bool app_quit = false;
-SDL_Renderer* renderer = nullptr;
-
-void main_loop() {
-    // Get events. If you are making a game, you probably want SDL_PollEvent instead of SDL_WaitEvent.
-    // you cannot use WaitEvent on Emscripten, because you cannot block the main thread there.
-
-    SDL_Event event;
-    while (SDL_PollEvent(&event)) {
-        if (event.type == SDL_EVENT_QUIT)
-            app_quit = true;
-        break;
-    }
-    
-    // draw a color
-    auto time = SDL_GetTicks() / 1000.f;
-    auto red = (std::sin(time) + 1) / 2.0 * 255;
-    auto green = (std::sin(time / 2) + 1) / 2.0 * 255;
-    auto blue = (std::sin(time) * 2 + 1) / 2.0 * 255;
-    
-    SDL_SetRenderDrawColor(renderer, red, green, blue, SDL_ALPHA_OPAQUE);
-    SDL_RenderClear(renderer);
-    SDL_RenderPresent(renderer);
-}
-
-// Note: your main function __must__ take this form, otherwise on nonstandard platforms (iOS, etc), your app will not launch.
-int main(int argc, char* argv[]){
-    
+int SDL_AppInit(void** appstate, int argc, char* argv[]) {
     // init the library, here we make a window so we only need the Video capabilities.
     if (SDL_Init(SDL_INIT_VIDEO)){
-        SDL_Fail();
+        return SDL_Fail();
     }
     
     // create a window
     SDL_Window* window = SDL_CreateWindow("Window", 352, 430, SDL_WINDOW_RESIZABLE);
     if (!window){
-        SDL_Fail();
+        return SDL_Fail();
     }
     
-    renderer = SDL_CreateRenderer(window, NULL, 0);
+    SDL_Renderer* renderer = SDL_CreateRenderer(window, NULL, 0);
     if (!renderer){
-        SDL_Fail();
+        return SDL_Fail();
     }
     
     // print some information about the window
@@ -71,25 +43,53 @@ int main(int argc, char* argv[]){
             SDL_Log("This is a highdpi environment.");
         }
     }
+
+    // set up the application data
+    app_data* app = (app_data*)SDL_malloc(sizeof(app_data));
+    app->window = window;
+    app->renderer = renderer;
+    app->app_quit = SDL_FALSE;
+    *appstate = (void*)app;
     
     SDL_Log("Application started successfully!");
-    
-#if __EMSCRIPTEN__
-    // on Emscripten, we cannot have an infinite loop in main. Instead, we must
-    // tell emscripten to call our main loop.
-    emscripten_set_main_loop(main_loop, 0, 1);
-#else
-    while (!app_quit) {
-        main_loop();
-    }
-#endif
 
-    // cleanup everything at the end
-#if !__EMSCRIPTEN__
-    SDL_DestroyRenderer(renderer);
-    SDL_DestroyWindow(window);
+    return 0;
+}
+
+int SDL_AppEvent(void *appstate, const SDL_Event* event) {
+    app_data* app = (app_data*)appstate;
+    
+    if (event->type == SDL_EVENT_QUIT) {
+        app->app_quit = SDL_TRUE;
+    }
+
+    return 0;
+}
+
+int SDL_AppIterate(void *appstate) {
+    app_data* app = (app_data*)appstate;
+
+    // draw a color
+    auto time = SDL_GetTicks() / 1000.f;
+    auto red = (std::sin(time) + 1) / 2.0 * 255;
+    auto green = (std::sin(time / 2) + 1) / 2.0 * 255;
+    auto blue = (std::sin(time) * 2 + 1) / 2.0 * 255;
+    
+    SDL_SetRenderDrawColor(app->renderer, red, green, blue, SDL_ALPHA_OPAQUE);
+    SDL_RenderClear(app->renderer);
+    SDL_RenderPresent(app->renderer);
+
+    return app->app_quit;
+}
+
+void SDL_AppQuit(void* appstate) {
+    app_data* app = (app_data*)appstate;
+    if (app) {
+        SDL_DestroyRenderer(app->renderer);
+        SDL_DestroyWindow(app->window);
+        SDL_free(app);
+    }
+
     SDL_Quit();
     SDL_Log("Application quit successfully!");
-#endif
-    return 0;
 }


### PR DESCRIPTION
This change adds use of `SDL_MAIN_USE_CALLBACKS`, which uses a more event-based approach to `main()`. The result is saving us from checking for `EMSCRIPTEN`. It did require an update to the latest prerelease build of SDL.

I've tested this on Linux and Emscripten and don't have the other platforms available to test on.
