### PR TITLE
Fixing apple iOS builds missing linkage, also fixing web build/deployment with latest actions

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -32,7 +32,9 @@ jobs:
            echo "::warning title=Invalid file permissions automatically fixed::$line"
          done
       - name: Upload 
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site/
         
  # Deploy job
   deploy:
@@ -54,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2 # or the latest "vX.X.X" version tag for this action
+        uses: actions/deploy-pages@v4 # or the latest "vX.X.X" version tag for this action

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,12 @@ target_link_libraries(${EXECUTABLE_NAME} PUBLIC
 	SDL3_image::SDL3_image	# remove if you are not using SDL_image
     SDL3::SDL3              # If using satelite libraries, SDL must be the last item in the list. 
 )
+
+if (APPLE)
+    find_library(IO_LIB ImageIO)
+    find_library(CS_LIB CoreServices)
+    target_link_libraries(${EXECUTABLE_NAME} PUBLIC ${IO_LIB} ${CS_LIB})
+endif()
 target_compile_definitions(${EXECUTABLE_NAME} PUBLIC SDL_MAIN_USE_CALLBACKS)
 
 # Dealing with assets


### PR DESCRIPTION
Github has deprecated the old actions and they now fail to deploy, this updates them to the latest and fixes the web build/deploy.