### PR TITLE
get rid of CMP0175 CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
+cmake_policy(SET CMP0175 OLD)
 
 # set the output directory for built objects.
 # This makes sure that the dynamic library goes into the build directory automatically.


### PR DESCRIPTION
CMake 3.30 and earlier silently ignored unsupported keywords and missing or invalid arguments for the different forms of the `add_custom_command()` command. CMake 3.31 implements more rigorous argument checking and will flag invalid or missing arguments as errors.

The `OLD` behavior of this policy will accept the same invalid keywords or arguments as CMake 3.30 and earlier.

See [CMP0175](https://cmake.org/cmake/help/latest/policy/CMP0175.html) docs.

---

On systems with CMake version 3.31 and higher - let's get rid of the warning.