### PR TITLE
Fix gcc [-Wconversion-null] warning: passing NULL to non-pointer argu…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,7 +117,7 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[]) {
 
     // play the music (does not loop)
     MIX_SetTrackAudio(mixerTrack, music);
-    MIX_PlayTrack(mixerTrack, NULL);
+    MIX_PlayTrack(mixerTrack, 0);
     
     // print some information about the window
     SDL_ShowWindow(window);


### PR DESCRIPTION
Hi,
I just compiled those samples using gcc (Debian 14.2.0-19). There is a NULL to zero conversion warning, I think and hope this is safe to replace with zero for every platform / compilers as I see `typedef Uint32 SDL_PropertiesID;` in SDL3/SDL_properties.h.

```
./src/main.cpp:120:31: warning: passing NULL to non-pointer argument 2 of ‘bool MIX_PlayTrack(MIX_Track*, SDL_PropertiesID)’ [-Wconversion-null]
  120 |     MIX_PlayTrack(mixerTrack, NULL);
      |                               ^~~~
In file included from ./src/main.cpp:6:
./SDL_mixer/include/SDL3_mixer/SDL_mixer.h:1922:83: note:   declared here
 1922 | extern SDL_DECLSPEC bool SDLCALL MIX_PlayTrack(MIX_Track *track, SDL_PropertiesID options);
      |                                                                  ~~~~~~~~~~~~~~~~~^~~~~~~
```